### PR TITLE
Add timed log retention

### DIFF
--- a/AlertSender.ps1
+++ b/AlertSender.ps1
@@ -356,13 +356,13 @@ Switch ($Config.services) {
 
 # Clean up old log files if configured
 if ($Config.log_expiry_days -ne 0) {
-	if ((Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)}).Count -ne 0) 
-	{
+	if ((Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)}).Count -ne 0) {
 		Write-LogMessage -Tag 'INFO' -Message "Found $FilesToRotate log files to rotate."
 		Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)} | Remove-Item
 		Write-LogMessage -Tag 'INFO' -Message "Deleted $FilesToRotate log files as part of rotation."
-	} else {
-		Write-LogMessage -Tag 'INFO' -Message "Found no logs files exceeding retention date for rotation."
+	} else 
+	{
+		Write-LogMessage -Tag 'INFO' -Message 'Found no logs files exceeding retention date for rotation.'
 	}
 }
 

--- a/AlertSender.ps1
+++ b/AlertSender.ps1
@@ -356,10 +356,11 @@ Switch ($Config.services) {
 
 # Clean up old log files if configured
 if ($Config.log_expiry_days -ne 0) {
-	if ((Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)}).Count -ne 0) {
-		Write-LogMessage -Tag 'INFO' -Message "Found $FilesToRotate log files to rotate."
-		Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)} | Remove-Item
-		Write-LogMessage -Tag 'INFO' -Message "Deleted $FilesToRotate log files as part of rotation."
+	$oldLogs = (Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)})
+	if ($($oldLogs.Count) -ne 0) {
+		Write-LogMessage -Tag 'INFO' -Message "Found $($oldLogs.Count) log files to rotate."
+		$oldLogs | Remove-Item
+		Write-LogMessage -Tag 'INFO' -Message "Deleted $($oldLogs.Count) log files as part of rotation."
 	}
 	else {
 		Write-LogMessage -Tag 'INFO' -Message 'Found no logs files exceeding retention date for rotation.'

--- a/AlertSender.ps1
+++ b/AlertSender.ps1
@@ -354,6 +354,17 @@ Switch ($Config.services) {
 	}
 }
 
+# Clean up old log files if configured
+if ($Config.log_expiry_days -ne 0) {
+	if ((Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)}).Count -ne 0) 
+	{
+		Write-LogMessage -Tag 'INFO' -Message "Found $FilesToRotate log files to rotate."
+		Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)} | Remove-Item
+		Write-LogMessage -Tag 'INFO' -Message "Deleted $FilesToRotate log files as part of rotation."
+	} else {
+		Write-LogMessage -Tag 'INFO' -Message "Found no logs files exceeding retention date for rotation."
+	}
+}
 
 # If newer version available...
 If ($updateStatus.Status -eq 'Behind') {

--- a/AlertSender.ps1
+++ b/AlertSender.ps1
@@ -360,8 +360,8 @@ if ($Config.log_expiry_days -ne 0) {
 		Write-LogMessage -Tag 'INFO' -Message "Found $FilesToRotate log files to rotate."
 		Get-ChildItem "$PSScriptRoot\log" | Where-Object { $_.CreationTime -lt (Get-Date).AddDays(-$Config.log_expiry_days)} | Remove-Item
 		Write-LogMessage -Tag 'INFO' -Message "Deleted $FilesToRotate log files as part of rotation."
-	} else 
-	{
+	}
+	else {
 		Write-LogMessage -Tag 'INFO' -Message 'Found no logs files exceeding retention date for rotation.'
 	}
 }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Configuration can be found in `C:\VeeamScripts\VeeamNotify\config\conf.json`
 | `self_update`        | boolean | False    | False             | When `true`, the script will update itself if there's a newer version available.                           |
 | `debug_log`          | boolean | False    | False             | When `true`, the script will log to a session-specific file in `C:\VeeamScripts\VeeamNotify\logs\`         |
 | `thumbnail`          | string  | False    | See example above | Image URL for the thumbnail shown in the report embed.                                                     |
-| `log_expiry_days`    | integer | False    | 7                 | Will delete logs older than value. Set to 0 to disable.                                                      |
+| `log_expiry_days`    | integer | False    | 7                 | Will delete logs older than value. Set to 0 to disable.                                                    |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Configuration can be found in `C:\VeeamScripts\VeeamNotify\config\conf.json`
 | `self_update`        | boolean | False    | False             | When `true`, the script will update itself if there's a newer version available.                           |
 | `debug_log`          | boolean | False    | False             | When `true`, the script will log to a session-specific file in `C:\VeeamScripts\VeeamNotify\logs\`         |
 | `thumbnail`          | string  | False    | See example above | Image URL for the thumbnail shown in the report embed.                                                     |
+| `log_expiry_days`    | integer | False    | 7                 | Will delete logs older than value. Set to 0 to disable.                                                      |
 
 ---
 

--- a/config/conf.json
+++ b/config/conf.json
@@ -20,5 +20,6 @@
 	"thumbnail": "https://raw.githubusercontent.com/tigattack/VeeamDiscordNotifications/master/asset/thumb01.png",
 	"notify_update": true,
 	"self_update": false,
-	"self_update_comment": "self_update will NOT work. Leave as 'false'."
+	"self_update_comment": "self_update will NOT work. Leave as 'false'.",
+	"log_expiry_days": 7
 }

--- a/config/conf.schema.json
+++ b/config/conf.schema.json
@@ -68,6 +68,9 @@
         },
         "comment": {
             "type": "string"
+        },
+        "log_expiry_days": {
+            "type": "integer"
         }
     },
     "required": [


### PR DESCRIPTION
I know this is on the [Work Tracker](https://github.com/tigattack/VeeamNotify/projects/1#card-78056550), thought I'd take it to get back into the project a bit.

Added a `log_expiry_days` parameter to the config along with the schema. 

In AlertSender.ps1 (Not sure if this is the right place for it, thought it may be ideal to do towards the end of the code run), there's a new code block with the new implementation.

If `log_expiry_days` isn't 0 (Disabled) it'll find all the logs that exceed the configured retention time (Default 7 days) and delete them.

I know the count in the if statement looks absolutely awful, however I think there's no requirement for an extra variable.