### PR TITLE
Refactor notification handling

### DIFF
--- a/.github/scripts/pssa-settings.psd1
+++ b/.github/scripts/pssa-settings.psd1
@@ -3,16 +3,17 @@
 	ExcludeRules = @(
 		'PSReviewUnusedParameter', # Required due to PowerShell/PSScriptAnalyzer#1472.
 		'PSAvoidLongLines',
-		'PSUseSingularNouns'
+		'PSUseSingularNouns',
+		'PSUseShouldProcessForStateChangingFunctions'
 	)
 	Rules = @{
-		PSAvoidUsingDoubleQuotesForConstantString = @{
+		PSAvoidUsingDoubleQuotesForConstantString   = @{
 			Enable = $true
 		}
-		PSAvoidUsingPositionalParameters = @{
+		PSAvoidUsingPositionalParameters            = @{
 			Enable = $true
 		}
-		PSUseCompatibleCommands = @{
+		PSUseCompatibleCommands                     = @{
 			Enable         = $true
 			# PowerShell platforms we want to check compatibility with
 			TargetProfiles = @(
@@ -27,7 +28,7 @@
 				#'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core' # PowerShell 7.0 on Windows 10
 			)
 		}
-		PSUseCompatibleSyntax = @{
+		PSUseCompatibleSyntax                       = @{
 			Enable         = $true
 			# PowerShell versions we want to check compatibility with
 			TargetVersions = @(
@@ -36,33 +37,33 @@
 				#'7.1'
 			)
 		}
-		PSPlaceCloseBrace = @{
+		PSPlaceCloseBrace                           = @{
 			Enable             = $true
 			NoEmptyLineBefore  = $false
 			IgnoreOneLineBlock = $true
 			NewLineAfter       = $true
 		}
-		PSPlaceOpenBrace = @{
+		PSPlaceOpenBrace                            = @{
 			Enable             = $true
 			OnSameLine         = $true
 			NewLineAfter       = $true
 			IgnoreOneLineBlock = $true
 		}
-		PSUseConsistentIndentation = @{
+		PSUseConsistentIndentation                  = @{
 			Enable              = $true
 			IndentationSize     = 4
 			PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
 			Kind                = 'tab'
 		}
-		PSAvoidLongLines = @{
+		PSAvoidLongLines                            = @{
 			Enable            = $true
 			MaximumLineLength = 155
 		}
-		PSAlignAssignmentStatement = @{
+		PSAlignAssignmentStatement                  = @{
 			Enable         = $true
 			CheckHashtable = $true
 		}
-		PSUseCorrectCasing = @{
+		PSUseCorrectCasing                          = @{
 			Enable = $true
 		}
 	}

--- a/AlertSender.ps1
+++ b/AlertSender.ps1
@@ -344,41 +344,17 @@ try {
 
 
 	# Build embed and send iiiit.
-	Switch ($Config.services) {
-		{ $_.discord.webhook.StartsWith('https') } {
-			Write-LogMessage -Tag 'INFO' -Message 'Sending notification to Discord.'
+	$Config.services.PSObject.Properties | ForEach-Object {
+		$service = $_
+		If ($service.Value.webhook.StartsWith('https')) {
+			Write-LogMessage -Tag 'INFO' -Message "Sending notification to $($service.Name)."
 
 			# Add user information for mention if relevant.
 			If ($mention) {
-				$payloadParams.UserId = $_.discord.user_id
+				$payloadParams.UserId = $service.Value.user_id
 			}
 
-			New-DiscordPayload @payloadParams | Send-Payload -Uri $Config.services.discord.webhook
-		}
-
-		{ $_.slack.webhook.StartsWith('https') } {
-			Write-LogMessage -Tag 'INFO' -Message 'Sending notification to Slack.'
-
-			# Add user information for mention if relevant.
-			If ($mention) {
-				$payloadParams.UserId = $_.slack.user_id
-			}
-
-			New-SlackPayload @payloadParams | Send-Payload -Uri $Config.services.slack.webhook
-		}
-
-		{ $_.teams.webhook.StartsWith('https') } {
-			Write-LogMessage -Tag 'INFO' -Message 'Sending notification to Teams.'
-
-			# Add user information for mention if relevant.
-			If ($mention) {
-				$payloadParams.UserId = $_.teams.user_id
-				If ($Config.teams_user_name -ne 'Your Name') {
-					$payloadParams.UserName = $_.teams.user_name
-				}
-			}
-
-			New-TeamsPayload @payloadParams | Send-Payload -Uri $Config.services.teams.webhook
+			New-Payload -Service $service.Name -Parameters $payloadParams | Send-Payload -Uri $service.Value.webhook
 		}
 	}
 

--- a/resources/NotificationHandler.psm1
+++ b/resources/NotificationHandler.psm1
@@ -1,4 +1,6 @@
 function New-Payload {
+	[CmdletBinding()]
+	[OutputType([System.Collections.Hashtable])]
 	param (
 		[Parameter(Mandatory=$true)]
 		[ValidateSet('Discord', 'Slack', 'Teams')]
@@ -25,10 +27,7 @@ function New-Payload {
 }
 
 function New-DiscordPayload {
-	[CmdletBinding(
-		SupportsShouldProcess,
-		ConfirmImpact = 'None'
-	)]
+	[CmdletBinding()]
 	[OutputType([System.Collections.Hashtable])]
 	param (
 		[string]$JobName,
@@ -52,174 +51,168 @@ function New-DiscordPayload {
 		[string]$LatestVersion
 	)
 
-	if ($PSCmdlet.ShouldProcess('Output stream', 'Create payload')) {
+	# Set Discord timestamps
+	$timestampStart = "<t:$(([System.DateTimeOffset]$(Get-Date $StartTime)).ToUnixTimeSeconds())>"
+	$timestampEnd = "<t:$(([System.DateTimeOffset]$(Get-Date $EndTime)).ToUnixTimeSeconds())>"
 
-		# Set Discord timestamps
-		$timestampStart = "<t:$(([System.DateTimeOffset]$(Get-Date $StartTime)).ToUnixTimeSeconds())>"
-		$timestampEnd = "<t:$(([System.DateTimeOffset]$(Get-Date $EndTime)).ToUnixTimeSeconds())>"
-
-		# Switch for the session status to decide the embed colour.
-		Switch ($Status) {
-			None { $colour = '16777215' }
-			Warning { $colour = '16776960' }
-			Success { $colour = '65280' }
-			Failed { $colour = '16711680' }
-			Default { $colour = '16777215' }
-		}
-
-		# Build footer object.
-		$footerObject = [PSCustomObject]@{
-			text     = $FooterMessage
-			icon_url = 'https://avatars0.githubusercontent.com/u/10629864'
-		}
-
-		## Build thumbnail object.
-		$thumbObject = [PSCustomObject]@{
-			url = $ThumbnailUrl
-		}
-
-		# Build field object.
-		if (-not ($JobType.EndsWith('Agent Backup'))) {
-			$fieldArray = @(
-				[PSCustomObject]@{
-					name   = 'Backup Size'
-					value  = $DataSize
-					inline = 'true'
-				},
-				[PSCustomObject]@{
-					name   = 'Transferred Data'
-					value  = $TransferSize
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Dedup Ratio'
-					value  = $DedupRatio
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Compression Ratio'
-					value  = $CompressRatio
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Processing Rate'
-					value  = $Speed
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Bottleneck'
-					value  = $Bottleneck
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Start Time'
-					value  = $timestampStart
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'End Time'
-					value  = $timestampEnd
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Duration'
-					value  = $Duration
-					inline = 'true'
-				}
-			)
-		}
-
-		elseif ($JobType.EndsWith('Agent Backup')) {
-			$fieldArray = @(
-				[PSCustomObject]@{
-					name   = 'Processed Size'
-					value  = $ProcessedSize
-					inline	= 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Transferred Data'
-					value  = $TransferSize
-					inline	= 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Processing Rate'
-					value  = $Speed
-					inline	= 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Bottleneck'
-					value  = $Bottleneck
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Start Time'
-					value  = $timestampStart
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'End Time'
-					value  = $timestampEnd
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Duration'
-					value  = $Duration
-					inline = 'true'
-				}
-				[PSCustomObject]@{
-					name   = 'Notice'
-					value  = "Further Agent session details are missing due to limitations in Veeam's PowerShell module."
-					inline = 'false'
-				}
-			)
-		}
-
-		# Build payload object.
-		[PSCustomObject]$payload = @{
-			embeds = @(
-				[PSCustomObject]@{
-					title       = $JobName
-					description	= "Session result: $Status`nJob type: $JobType"
-					color       = $Colour
-					thumbnail   = $thumbObject
-					fields      = $fieldArray
-					footer      = $footerObject
-					timestamp   = $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffK'))
-				}
-			)
-		}
-
-		# Mention user if configured to do so.
-		If ($mention) {
-			$payload += @{
-				content = "<@!$($UserId)> Job $($Status.ToLower())!"
-			}
-		}
-
-		# Add update notice if relevant and configured to do so.
-		If ($UpdateNotification) {
-			# Add embed to payload.
-			$payload.embeds += @(
-				@{
-					title       = 'Update Available'
-					description	= "A new version of VeeamNotify is available!`n[See release **$LatestVersion** on GitHub](https://github.com/tigattack/VeeamNotify/releases/$LatestVersion)."
-					color       = 3429867
-					footer      = $footerObject
-					timestamp   = $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffK'))
-				}
-			)
-		}
-
-		# Return payload object.
-		return $payload
+	# Switch for the session status to decide the embed colour.
+	Switch ($Status) {
+		None { $colour = '16777215' }
+		Warning { $colour = '16776960' }
+		Success { $colour = '65280' }
+		Failed { $colour = '16711680' }
+		Default { $colour = '16777215' }
 	}
+
+	# Build footer object.
+	$footerObject = [PSCustomObject]@{
+		text     = $FooterMessage
+		icon_url = 'https://avatars0.githubusercontent.com/u/10629864'
+	}
+
+	## Build thumbnail object.
+	$thumbObject = [PSCustomObject]@{
+		url = $ThumbnailUrl
+	}
+
+	# Build field object.
+	if (-not ($JobType.EndsWith('Agent Backup'))) {
+		$fieldArray = @(
+			[PSCustomObject]@{
+				name   = 'Backup Size'
+				value  = $DataSize
+				inline = 'true'
+			},
+			[PSCustomObject]@{
+				name   = 'Transferred Data'
+				value  = $TransferSize
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Dedup Ratio'
+				value  = $DedupRatio
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Compression Ratio'
+				value  = $CompressRatio
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Processing Rate'
+				value  = $Speed
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Bottleneck'
+				value  = $Bottleneck
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Start Time'
+				value  = $timestampStart
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'End Time'
+				value  = $timestampEnd
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Duration'
+				value  = $Duration
+				inline = 'true'
+			}
+		)
+	}
+
+	elseif ($JobType.EndsWith('Agent Backup')) {
+		$fieldArray = @(
+			[PSCustomObject]@{
+				name   = 'Processed Size'
+				value  = $ProcessedSize
+				inline	= 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Transferred Data'
+				value  = $TransferSize
+				inline	= 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Processing Rate'
+				value  = $Speed
+				inline	= 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Bottleneck'
+				value  = $Bottleneck
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Start Time'
+				value  = $timestampStart
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'End Time'
+				value  = $timestampEnd
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Duration'
+				value  = $Duration
+				inline = 'true'
+			}
+			[PSCustomObject]@{
+				name   = 'Notice'
+				value  = "Further Agent session details are missing due to limitations in Veeam's PowerShell module."
+				inline = 'false'
+			}
+		)
+	}
+
+	# Build payload object.
+	[PSCustomObject]$payload = @{
+		embeds = @(
+			[PSCustomObject]@{
+				title       = $JobName
+				description	= "Session result: $Status`nJob type: $JobType"
+				color       = $Colour
+				thumbnail   = $thumbObject
+				fields      = $fieldArray
+				footer      = $footerObject
+				timestamp   = $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffK'))
+			}
+		)
+	}
+
+	# Mention user if configured to do so.
+	If ($mention) {
+		$payload += @{
+			content = "<@!$($UserId)> Job $($Status.ToLower())!"
+		}
+	}
+
+	# Add update notice if relevant and configured to do so.
+	If ($UpdateNotification) {
+		# Add embed to payload.
+		$payload.embeds += @(
+			@{
+				title       = 'Update Available'
+				description	= "A new version of VeeamNotify is available!`n[See release **$LatestVersion** on GitHub](https://github.com/tigattack/VeeamNotify/releases/$LatestVersion)."
+				color       = 3429867
+				footer      = $footerObject
+				timestamp   = $((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffK'))
+			}
+		)
+	}
+
+	# Return payload object.
+	return $payload
 }
 
 function New-TeamsPayload {
-	[CmdletBinding(
-		SupportsShouldProcess,
-		ConfirmImpact = 'None'
-	)]
+	[CmdletBinding()]
 	[OutputType([System.Collections.Hashtable])]
 	param (
 		[string]$JobName,
@@ -244,279 +237,273 @@ function New-TeamsPayload {
 		[string]$LatestVersion
 	)
 
-	if ($PSCmdlet.ShouldProcess('Output stream', 'Create payload')) {
+	# Define username
+	If (-not $UserName) {
+		$UserName = $($UserId.Split('@')[0])
+	}
 
-		# Define username
-		If (-not $UserName) {
-			$UserName = $($UserId.Split('@')[0])
-		}
+	# Mention user if configured to do so.
+	# Must be done at early stage to ensure this section is at the top of the embed object.
+	If ($mention) {
+		$bodyArray = @(
+			@{
+				type = 'TextBlock'
+				text = "<at>$UserName</at> Job $($Status.ToLower())!"
+				wrap = $true
+			}
+		)
+	}
+	else {
+		$bodyArray = @()
+	}
 
-		# Mention user if configured to do so.
-		# Must be done at early stage to ensure this section is at the top of the embed object.
-		If ($mention) {
-			$bodyArray = @(
-				@{
-					type = 'TextBlock'
-					text = "<at>$UserName</at> Job $($Status.ToLower())!"
-					wrap = $true
+	# Set timestamps
+	$timestampStart = $(Get-Date $StartTime -UFormat '%d %B %Y %R').ToString()
+	$timestampEnd = $(Get-Date $EndTime -UFormat '%d %B %Y %R').ToString()
+
+	# Add embedded URL to footer message
+	$FooterMessage = $FooterMessage.Replace(
+		'VeeamNotify',
+		'[VeeamNotify](https://github.com/tigattack/VeeamNotify)'
+	)
+
+	# Add URL to update notice if relevant and configured to do so.
+	If ($UpdateNotification) {
+		# Add URL to update notice.
+		$FooterMessage += "  `n[See release **$LatestVersion** on GitHub.](https://github.com/tigattack/VeeamNotify/releases/$LatestVersion)"
+	}
+
+	# Add header information to body array
+	$bodyArray += @(
+		@{ type = 'ColumnSet'; columns = @(
+				@{ type = 'Column'; width = 'stretch'; items = @(
+						@{
+							type    = 'TextBlock'
+							text    = "**$jobName**"
+							wrap    = $true
+							spacing = 'None'
+						}
+						@{
+							type     = 'TextBlock'
+							text     = "$((Get-Date -UFormat '%d %B %Y %R').ToString())"
+							wrap     = $true
+							isSubtle = $true
+							spacing  = 'None'
+						}
+						@{ type = 'FactSet'; facts = @(
+								@{
+									title = 'Session Result'
+									value = "$Status"
+								}
+								@{
+									title = 'Job Type'
+									value = "$jobType"
+								}
+							)
+							spacing = 'Small'
+						}
+					)
+				}
+				@{ type = 'Column'; width = 'auto'; items = @(
+						@{
+							type   = 'Image'
+							url    = "$thumbnailUrl"
+							height = '80px'
+						}
+					)
 				}
 			)
 		}
-		else {
-			$bodyArray = @()
-		}
+	)
 
-		# Set timestamps
-		$timestampStart = $(Get-Date $StartTime -UFormat '%d %B %Y %R').ToString()
-		$timestampEnd = $(Get-Date $EndTime -UFormat '%d %B %Y %R').ToString()
-
-		# Add embedded URL to footer message
-		$FooterMessage = $FooterMessage.Replace(
-			'VeeamNotify',
-			'[VeeamNotify](https://github.com/tigattack/VeeamNotify)'
-		)
-
-		# Add URL to update notice if relevant and configured to do so.
-		If ($UpdateNotification) {
-			# Add URL to update notice.
-			$FooterMessage += "  `n[See release **$LatestVersion** on GitHub.](https://github.com/tigattack/VeeamNotify/releases/$LatestVersion)"
-		}
-
-		# Add header information to body array
+	# Add job information to body array
+	if (-not ($JobType.EndsWith('Agent Backup'))) {
 		$bodyArray += @(
 			@{ type = 'ColumnSet'; columns = @(
 					@{ type = 'Column'; width = 'stretch'; items = @(
 							@{
-								type    = 'TextBlock'
-								text    = "**$jobName**"
-								wrap    = $true
-								spacing = 'None'
-							}
-							@{
-								type     = 'TextBlock'
-								text     = "$((Get-Date -UFormat '%d %B %Y %R').ToString())"
-								wrap     = $true
-								isSubtle = $true
-								spacing  = 'None'
-							}
-							@{ type = 'FactSet'; facts = @(
+								type  = 'FactSet'
+								facts = @(
 									@{
-										title = 'Session Result'
-										value = "$Status"
+										title = 'Backup size'
+										value = "$DataSize"
 									}
 									@{
-										title = 'Job Type'
-										value = "$jobType"
+										title = 'Transferred data'
+										value = "$transferSize"
+									}
+									@{
+										title = 'Dedup ratio'
+										value = "$DedupRatio"
+									}
+									@{
+										title = 'Compress ratio'
+										value = "$CompressRatio"
+									}
+									@{
+										title = 'Processing rate'
+										value = "$Speed"
 									}
 								)
-								spacing = 'Small'
-							}
-						)
-					}
-					@{ type = 'Column'; width = 'auto'; items = @(
-							@{
-								type   = 'Image'
-								url    = "$thumbnailUrl"
-								height = '80px'
-							}
-						)
-					}
-				)
-			}
-		)
-
-		# Add job information to body array
-		if (-not ($JobType.EndsWith('Agent Backup'))) {
-			$bodyArray += @(
-				@{ type = 'ColumnSet'; columns = @(
-						@{ type = 'Column'; width = 'stretch'; items = @(
-								@{
-									type  = 'FactSet'
-									facts = @(
-										@{
-											title = 'Backup size'
-											value = "$DataSize"
-										}
-										@{
-											title = 'Transferred data'
-											value = "$transferSize"
-										}
-										@{
-											title = 'Dedup ratio'
-											value = "$DedupRatio"
-										}
-										@{
-											title = 'Compress ratio'
-											value = "$CompressRatio"
-										}
-										@{
-											title = 'Processing rate'
-											value = "$Speed"
-										}
-									)
-								}
-							)
-						}
-						@{ type = 'Column'; width = 'stretch'; items = @(
-								@{ type = 'FactSet'; facts = @(
-										@{
-											title = 'Bottleneck'
-											value = "$Bottleneck"
-										}
-										@{
-											title = 'Start Time'
-											value = "$timestampStart"
-										}
-										@{
-											title = 'End Time'
-											value = "$timestampEnd"
-										}
-										@{
-											title = 'Duration'
-											value = "$Duration"
-										}
-									)
-								}
-							)
-						}
-					)
-				}
-			)
-		}
-
-		elseif ($JobType.EndsWith('Agent Backup')) {
-			$bodyArray += @(
-				@{ type = 'ColumnSet'; columns = @(
-						@{ type = 'Column'; width = 'stretch'; items = @(
-								@{
-									type  = 'FactSet'
-									facts = @(
-										@{
-											title = 'Processed Size'
-											value = "$ProcessedSize"
-										}
-										@{
-											title = 'Transferred Data'
-											value = "$transferSize"
-										}
-										@{
-											title = 'Processing rate'
-											value = "$Speed"
-										}
-										@{
-											title = 'Bottleneck'
-											value = "$Bottleneck"
-										}
-									)
-								}
-							)
-						}
-						@{ type = 'Column'; width = 'stretch'; items = @(
-								@{ type = 'FactSet'; facts = @(
-										@{
-											title = 'Start Time'
-											value = "$timestampStart"
-										}
-										@{
-											title = 'End Time'
-											value = "$timestampEnd"
-										}
-										@{
-											title = 'Duration'
-											value = "$Duration"
-										}
-									)
-								}
-							)
-						}
-					)
-				}
-				@{ type = 'ColumnSet'; columns = @(
-						@{ type = 'Column'; width = 'stretch'; items = @(
-								@{
-									type  = 'FactSet'
-									facts = @(
-										@{
-											title = 'Notice'
-											value = "Further Agent session details are missing due to limitations in Veeam's PowerShell module."
-										}
-									)
-								}
-							)
-						}
-					)
-				}
-			)
-		}
-
-		# Add footer information to the body array
-		$bodyArray += @(
-			@{ type = 'ColumnSet'; separator = $true ; columns = @(
-					@{ type = 'Column'; width = 'auto'; items = @(
-							@{
-								type   = 'Image'
-								url    = 'https://avatars0.githubusercontent.com/u/10629864'
-								height = '20px'
 							}
 						)
 					}
 					@{ type = 'Column'; width = 'stretch'; items = @(
-							@{
-								type     = 'TextBlock'
-								text     = "$FooterMessage"
-								wrap     = $true
-								isSubtle = $true
+							@{ type = 'FactSet'; facts = @(
+									@{
+										title = 'Bottleneck'
+										value = "$Bottleneck"
+									}
+									@{
+										title = 'Start Time'
+										value = "$timestampStart"
+									}
+									@{
+										title = 'End Time'
+										value = "$timestampEnd"
+									}
+									@{
+										title = 'Duration'
+										value = "$Duration"
+									}
+								)
 							}
 						)
 					}
 				)
 			}
 		)
+	}
 
-		[PSCustomObject]$payload = @{
-			type        = 'message'
-			attachments = @(
-				@{
-					contentType = 'application/vnd.microsoft.card.adaptive'
-					contentUrl  = $null
-					content     = @{
-						'$schema' = 'http://adaptivecards.io/schemas/adaptive-card.json'
-						type      = 'AdaptiveCard'
-						version   = '1.4'
-						body      = $bodyArray
-					}
-				}
-			)
-		}
-
-		# Mention user if configured to do so.
-		# Must be done at early stage to ensure this section is at the top of the embed object.
-		If ($mention) {
-			$payload.attachments[0].content += @{
-				msteams = @{
-					entities = @(
-						@{
-							type      = 'mention'
-							text      = "<at>$UserName</at>"
-							mentioned = @{
-								id   = "$UserId"
-								name = "$UserName"
+	elseif ($JobType.EndsWith('Agent Backup')) {
+		$bodyArray += @(
+			@{ type = 'ColumnSet'; columns = @(
+					@{ type = 'Column'; width = 'stretch'; items = @(
+							@{
+								type  = 'FactSet'
+								facts = @(
+									@{
+										title = 'Processed Size'
+										value = "$ProcessedSize"
+									}
+									@{
+										title = 'Transferred Data'
+										value = "$transferSize"
+									}
+									@{
+										title = 'Processing rate'
+										value = "$Speed"
+									}
+									@{
+										title = 'Bottleneck'
+										value = "$Bottleneck"
+									}
+								)
 							}
+						)
+					}
+					@{ type = 'Column'; width = 'stretch'; items = @(
+							@{ type = 'FactSet'; facts = @(
+									@{
+										title = 'Start Time'
+										value = "$timestampStart"
+									}
+									@{
+										title = 'End Time'
+										value = "$timestampEnd"
+									}
+									@{
+										title = 'Duration'
+										value = "$Duration"
+									}
+								)
+							}
+						)
+					}
+				)
+			}
+			@{ type = 'ColumnSet'; columns = @(
+					@{ type = 'Column'; width = 'stretch'; items = @(
+							@{
+								type  = 'FactSet'
+								facts = @(
+									@{
+										title = 'Notice'
+										value = "Further Agent session details are missing due to limitations in Veeam's PowerShell module."
+									}
+								)
+							}
+						)
+					}
+				)
+			}
+		)
+	}
+
+	# Add footer information to the body array
+	$bodyArray += @(
+		@{ type = 'ColumnSet'; separator = $true ; columns = @(
+				@{ type = 'Column'; width = 'auto'; items = @(
+						@{
+							type   = 'Image'
+							url    = 'https://avatars0.githubusercontent.com/u/10629864'
+							height = '20px'
 						}
 					)
 				}
+				@{ type = 'Column'; width = 'stretch'; items = @(
+						@{
+							type     = 'TextBlock'
+							text     = "$FooterMessage"
+							wrap     = $true
+							isSubtle = $true
+						}
+					)
+				}
+			)
+		}
+	)
+
+	[PSCustomObject]$payload = @{
+		type        = 'message'
+		attachments = @(
+			@{
+				contentType = 'application/vnd.microsoft.card.adaptive'
+				contentUrl  = $null
+				content     = @{
+					'$schema' = 'http://adaptivecards.io/schemas/adaptive-card.json'
+					type      = 'AdaptiveCard'
+					version   = '1.4'
+					body      = $bodyArray
+				}
+			}
+		)
+	}
+
+	# Mention user if configured to do so.
+	# Must be done at early stage to ensure this section is at the top of the embed object.
+	If ($mention) {
+		$payload.attachments[0].content += @{
+			msteams = @{
+				entities = @(
+					@{
+						type      = 'mention'
+						text      = "<at>$UserName</at>"
+						mentioned = @{
+							id   = "$UserId"
+							name = "$UserName"
+						}
+					}
+				)
 			}
 		}
-
-		return $payload
 	}
+
+	return $payload
 }
 
 function New-SlackPayload {
-	[CmdletBinding(
-		SupportsShouldProcess,
-		ConfirmImpact = 'None'
-	)]
+	[CmdletBinding()]
 	[OutputType([System.Collections.Hashtable])]
 	param (
 		[string]$JobName,
@@ -540,192 +527,189 @@ function New-SlackPayload {
 		[string]$LatestVersion
 	)
 
-	if ($PSCmdlet.ShouldProcess('Output stream', 'Create payload')) {
-
-		# Mention user if configured to do so.
-		# Must be done at early stage to ensure this section is at the top of the embed object.
-		If ($mention) {
-			$payload = @{
-				blocks = @(
-					@{
-						type = 'section'
-						text = @{
-							type = 'mrkdwn'
-							text = "<@$UserId> Job $($Status.ToLower())!"
-						}
-					}
-				)
-			}
-		}
-		else {
-			$payload = @{
-				blocks = @()
-			}
-		}
-
-		# Set timestamps
-		$timestampStart = $(Get-Date $StartTime -UFormat '%d %B %Y %R').ToString()
-		$timestampEnd = $(Get-Date $EndTime -UFormat '%d %B %Y %R').ToString()
-
-		# Build blocks object.
-		if (-not ($JobType.EndsWith('Agent Backup'))) {
-			$fieldArray = @(
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Backup Size*`n$DataSize"
-				},
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Transferred Data*`n$TransferSize"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Dedup Ratio*`n$DedupRatio"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Compression Ratio*`n$CompressRatio"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Processing Rate*`n$Speed"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Bottleneck*`n$Bottleneck"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Start Time*`n$timestampStart"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*End Time*`n$timestampEnd"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Duration*`n$Duration"
-				}
-			)
-		}
-
-		elseif ($JobType.EndsWith('Agent Backup')) {
-			$fieldArray += @(
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Processed Size*`n$ProcessedSize"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Transferred Data*`n$TransferSize"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Processing Rate*`n$Speed"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Bottleneck*`n$Bottleneck"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Start Time*`n$timestampStart"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*End Time*`n$timestampEnd"
-				}
-				[PSCustomObject]@{
-					type = 'mrkdwn'
-					text = "*Duration*`n$Duration"
-				}
-			)
-		}
-
-		# Build payload object.
-		[PSCustomObject]$payload.blocks += @(
-			@{
-				type      = 'section'
-				text      = @{
-					type = 'mrkdwn'
-					text = "*$JobName*`n`nSession result: $Status`nJob type: $JobType"
-				}
-				accessory = @{
-					type      = 'image'
-					image_url = "$ThumbnailUrl"
-					alt_text  = 'Veeam Backup & Replication logo'
-				}
-			}
-			@{
-				type   = 'section'
-				fields = $fieldArray
-			}
-		)
-
-		# Add agent notice if applicable.
-		if ($JobType.EndsWith('Agent Backup')) {
-			$payload.blocks += @(
+	# Mention user if configured to do so.
+	# Must be done at early stage to ensure this section is at the top of the embed object.
+	If ($mention) {
+		$payload = @{
+			blocks = @(
 				@{
 					type = 'section'
 					text = @{
 						type = 'mrkdwn'
-						text = "*Notice*`nFurther Agent session details are missing due to limitations in Veeam's PowerShell module."
+						text = "<@$UserId> Job $($Status.ToLower())!"
 					}
 				}
 			)
 		}
+	}
+	else {
+		$payload = @{
+			blocks = @()
+		}
+	}
 
-		# Add footer to payload object.
-		$payload.blocks += @(
-			@{
-				type = 'divider'
+	# Set timestamps
+	$timestampStart = $(Get-Date $StartTime -UFormat '%d %B %Y %R').ToString()
+	$timestampEnd = $(Get-Date $EndTime -UFormat '%d %B %Y %R').ToString()
+
+	# Build blocks object.
+	if (-not ($JobType.EndsWith('Agent Backup'))) {
+		$fieldArray = @(
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Backup Size*`n$DataSize"
+			},
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Transferred Data*`n$TransferSize"
 			}
-			@{
-				type     = 'context'
-				elements = @(
-					@{
-						type      = 'image'
-						image_url = 'https://avatars0.githubusercontent.com/u/10629864'
-						alt_text  = "tigattack's avatar"
-					}
-					@{
-						type = 'plain_text'
-						text = $FooterMessage
-					}
-				)
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Dedup Ratio*`n$DedupRatio"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Compression Ratio*`n$CompressRatio"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Processing Rate*`n$Speed"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Bottleneck*`n$Bottleneck"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Start Time*`n$timestampStart"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*End Time*`n$timestampEnd"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Duration*`n$Duration"
 			}
 		)
+	}
 
-		# Add update notice if relevant and configured to do so.
-		If ($UpdateNotification) {
-			# Add block to payload.
-			$payload.blocks += @(
+	elseif ($JobType.EndsWith('Agent Backup')) {
+		$fieldArray += @(
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Processed Size*`n$ProcessedSize"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Transferred Data*`n$TransferSize"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Processing Rate*`n$Speed"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Bottleneck*`n$Bottleneck"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Start Time*`n$timestampStart"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*End Time*`n$timestampEnd"
+			}
+			[PSCustomObject]@{
+				type = 'mrkdwn'
+				text = "*Duration*`n$Duration"
+			}
+		)
+	}
+
+	# Build payload object.
+	[PSCustomObject]$payload.blocks += @(
+		@{
+			type      = 'section'
+			text      = @{
+				type = 'mrkdwn'
+				text = "*$JobName*`n`nSession result: $Status`nJob type: $JobType"
+			}
+			accessory = @{
+				type      = 'image'
+				image_url = "$ThumbnailUrl"
+				alt_text  = 'Veeam Backup & Replication logo'
+			}
+		}
+		@{
+			type   = 'section'
+			fields = $fieldArray
+		}
+	)
+
+	# Add agent notice if applicable.
+	if ($JobType.EndsWith('Agent Backup')) {
+		$payload.blocks += @(
+			@{
+				type = 'section'
+				text = @{
+					type = 'mrkdwn'
+					text = "*Notice*`nFurther Agent session details are missing due to limitations in Veeam's PowerShell module."
+				}
+			}
+		)
+	}
+
+	# Add footer to payload object.
+	$payload.blocks += @(
+		@{
+			type = 'divider'
+		}
+		@{
+			type     = 'context'
+			elements = @(
 				@{
-					type      = 'section'
-					text      = @{
-						type = 'mrkdwn'
-						text = "A new version of VeeamNotify is available! See release *$LatestVersion* on GitHub."
-					}
-					accessory = @{
-						type      = 'button'
-						text      = @{
-							type = 'plain_text'
-							text = 'Open on GitHub'
-						}
-						value     = 'open_github'
-						url       = "https://github.com/tigattack/VeeamNotify/releases/$LatestVersion"
-						action_id = 'button-action'
-					}
+					type      = 'image'
+					image_url = 'https://avatars0.githubusercontent.com/u/10629864'
+					alt_text  = "tigattack's avatar"
+				}
+				@{
+					type = 'plain_text'
+					text = $FooterMessage
 				}
 			)
 		}
+	)
 
-		# Remove obsolete extended-type system properties added by Add-Member ($payload.blocks +=)
-		# https://stackoverflow.com/a/57599481
-		Remove-TypeData System.Array -ErrorAction Ignore
-
-		return $payload
+	# Add update notice if relevant and configured to do so.
+	If ($UpdateNotification) {
+		# Add block to payload.
+		$payload.blocks += @(
+			@{
+				type      = 'section'
+				text      = @{
+					type = 'mrkdwn'
+					text = "A new version of VeeamNotify is available! See release *$LatestVersion* on GitHub."
+				}
+				accessory = @{
+					type      = 'button'
+					text      = @{
+						type = 'plain_text'
+						text = 'Open on GitHub'
+					}
+					value     = 'open_github'
+					url       = "https://github.com/tigattack/VeeamNotify/releases/$LatestVersion"
+					action_id = 'button-action'
+				}
+			}
+		)
 	}
+
+	# Remove obsolete extended-type system properties added by Add-Member ($payload.blocks +=)
+	# https://stackoverflow.com/a/57599481
+	Remove-TypeData System.Array -ErrorAction Ignore
+
+	return $payload
 }
 
 function Send-Payload {

--- a/resources/NotificationHandler.psm1
+++ b/resources/NotificationHandler.psm1
@@ -1,3 +1,29 @@
+function New-Payload {
+	param (
+		[Parameter(Mandatory=$true)]
+		[ValidateSet('Discord', 'Slack', 'Teams')]
+		[string]$Service,
+
+		[Parameter(Mandatory=$true)]
+		[Hashtable]$Parameters
+	)
+
+	switch ($Service) {
+		'Discord' {
+			New-DiscordPayload @Parameters
+		}
+		'Slack' {
+			New-SlackPayload @Parameters
+		}
+		'Teams' {
+			New-TeamsPayload @Parameters
+		}
+		Default {
+			Write-LogMessage -Tag 'Error' -Message "Unknown service: $Service"
+		}
+	}
+}
+
 function New-DiscordPayload {
 	[CmdletBinding(
 		SupportsShouldProcess,


### PR DESCRIPTION
Add `New-Payload` function to `NotificationHandler` module to wrap `New-DiscordPayload`, `New-SlackPayload`, `New-TeamsPayload`, and any future `New-<service>Payload` functions.

In `AlertSender`, the switch on the `services` config object is then removed. Instead, we iterate over the `services` config object instead, piping `New-Payload` into `Send-Payload` for each service.

Same functionality as before, but more scalable since all service changes are isolated to `conf.json` and `NotificationHandler.psm1`.