### PR TITLE
installer: fix branch download

### DIFF
--- a/Installer.ps1
+++ b/Installer.ps1
@@ -76,15 +76,15 @@ foreach ($i in $releases) {
 # Query download type if not specified
 If (-not $Version -and -not $Latest -and -not $Branch -and -not $NonInteractive) {
 
-	# Query download type
+	# Query download type / release stream
 	[System.Management.Automation.Host.ChoiceDescription[]]$downloadQuery_opts = @()
 	If ($releases) {
 		$downloadQuery_message = "Please select how you would like to download $project."
+		$downloadQuery_opts += New-Object System.Management.Automation.Host.ChoiceDescription '&Release', "Download the latest release or prerelease. You will be prompted if there's a choice between the two."
 	}
 	Else {
-		$downloadQuery_message = "Please select how you would like to download $project. NOTE: there are currently no releases or prereleases available."
+		$downloadQuery_message = "Please select how you would like to download $project.`Note there are currently no releases or prereleases available."
 	}
-	$downloadQuery_opts += New-Object System.Management.Automation.Host.ChoiceDescription '&Release', "Download the latest release or prerelease. You will be prompted if there's a choice between the two."
 	$downloadQuery_opts += New-Object System.Management.Automation.Host.ChoiceDescription '&Version', 'Download a specific version.'
 	$downloadQuery_opts += New-Object System.Management.Automation.Host.ChoiceDescription '&Branch', 'Download a branch.'
 	$downloadQuery_result = $host.UI.PromptForChoice(
@@ -112,9 +112,6 @@ If (-not $Version -and -not $Latest -and -not $Branch -and -not $NonInteractive)
 	# Set download type
 	Switch ($downloadType) {
 		'release' {
-			If (-not $releases) {
-				Write-Output "`nThere are currently no releases available. Please"
-			}
 			If ($latestStable -and $latestPrerelease) {
 				# Query release stream
 				$releasePrompt = $true

--- a/Installer.ps1
+++ b/Installer.ps1
@@ -40,9 +40,10 @@ Write-Output @'
 
 # Check if this project is already installed and if so, exit
 if (Test-Path "$InstallParentPath\$project") {
-	$installedVersion = Get-Content -Raw "$InstallParentPath\$project\resources\version.txt"
+	$installedVersion = (Get-Content -Raw "$InstallParentPath\$project\resources\version.txt").Trim()
 	Write-Output "$project ($installedVersion) is already installed. This script cannot update an existing installation."
 	Write-Output 'Please manually update or delete/rename the existing installation and retry.'
+	exit
 }
 
 

--- a/Installer.ps1
+++ b/Installer.ps1
@@ -270,18 +270,17 @@ Else {
 		}
 	}
 }
-# Set visual releaseName to not cause confusion vs input
-$VisualReleaseName = $releaseName
-# Sanitize releaseName for OutFile
-$releaseName = $releaseName -replace '[\W]', '-'
+
+# Sanitise releaseName for OutFile
+$outFile = "$env:TEMP\$project-$($releaseName -replace '[\W]','-')"
 
 # Download project from GitHub
 $DownloadParams = @{
 	Uri     = $downloadUrl
-	OutFile = "$env:TEMP\$project-$releaseName.zip"
+	OutFile = "$env:TEMP\$outFile.zip"
 }
 Try {
-	Write-Output "`nDownloading $project $VisualReleaseName from GitHub..."
+	Write-Output "`nDownloading $project $releaseName from GitHub..."
 	Invoke-WebRequest @DownloadParams
 }
 catch {
@@ -293,7 +292,7 @@ catch {
 # Unblock downloaded ZIP
 try {
 	Write-Output 'Unblocking ZIP...'
-	Unblock-File -Path "$env:TEMP\$project-$releaseName.zip"
+	Unblock-File -Path "$env:TEMP\$outFile.zip"
 }
 catch {
 	Write-Warning 'Failed to unblock downloaded files. You will need to run the following commands manually once installation is complete:'
@@ -302,12 +301,12 @@ catch {
 
 # Extract release to destination path
 Write-Output "Extracting files to '$InstallParentPath'..."
-Expand-Archive -Path "$env:TEMP\$project-$releaseName.zip" -DestinationPath "$InstallParentPath"
+Expand-Archive -Path "$env:TEMP\$outFile.zip" -DestinationPath "$InstallParentPath"
 
 # Rename destination and tidy up
 Write-Output "Renaming directory and tidying up...`n"
-Rename-Item -Path "$InstallParentPath\$project-$releaseName" -NewName "$project"
-Remove-Item -Path "$env:TEMP\$project-$releaseName.zip"
+Rename-Item -Path "$InstallParentPath\$outFile" -NewName "$project"
+Remove-Item -Path "$env:TEMP\$outFile.zip"
 
 If (-not $NonInteractive) {
 	# Get config

--- a/Installer.ps1
+++ b/Installer.ps1
@@ -275,7 +275,7 @@ Else {
 }
 
 # Sanitise releaseName for OutFile
-$outFile = "$env:TEMP\$project-$($releaseName -replace '[\W]','-')"
+$outFile = "$project-$($releaseName -replace '[\W]','-')"
 
 # Download project from GitHub
 $DownloadParams = @{

--- a/Installer.ps1
+++ b/Installer.ps1
@@ -86,7 +86,7 @@ If (-not $Version -and
 		$downloadQuery_opts += New-Object System.Management.Automation.Host.ChoiceDescription '&Release', "Download the latest release or prerelease. You will be prompted if there's a choice between the two."
 	}
 	Else {
-		$downloadQuery_message = "Please select how you would like to download $project.`Note there are currently no releases or prereleases available."
+		$downloadQuery_message = "Please select how you would like to download $project.`nNote there are currently no releases or prereleases available."
 	}
 	$downloadQuery_opts += New-Object System.Management.Automation.Host.ChoiceDescription '&Version', 'Download a specific version.'
 	$downloadQuery_opts += New-Object System.Management.Automation.Host.ChoiceDescription '&Branch', 'Download a branch.'

--- a/Installer.ps1
+++ b/Installer.ps1
@@ -250,6 +250,10 @@ Else {
 	# Define download URL
 	$downloadUrl = "https://github.com/tigattack/$project/releases/download/$releaseName/$project-$releaseName.zip"
 }
+# Set visual releaseName to not cause confusion vs input
+$VisualReleaseName = $releaseName
+# Sanitize releaseName for OutFile
+$releaseName = $releaseName -replace '[\W]', '-'
 
 # Download project from GitHub
 $DownloadParams = @{
@@ -257,7 +261,7 @@ $DownloadParams = @{
 	OutFile = "$env:TEMP\$project-$releaseName.zip"
 }
 Try {
-	Write-Output "`nDownloading $project $releaseName from GitHub..."
+	Write-Output "`nDownloading $project $VisualReleaseName from GitHub..."
 	Invoke-WebRequest @DownloadParams
 }
 catch {

--- a/Installer.ps1
+++ b/Installer.ps1
@@ -54,7 +54,7 @@ try {
 }
 catch {
 	$versionStatusCode = $_.Exception.Response.StatusCode.value__
-	Write-Warning "Failed to query GitHub for $project releases. Please check your internet connection and try again."
+	Write-Warning "Failed to query GitHub for $project releases."
 	throw "HTTP status code: $versionStatusCode"
 }
 
@@ -74,7 +74,10 @@ foreach ($i in $releases) {
 
 
 # Query download type if not specified
-If (-not $Version -and -not $Latest -and -not $Branch -and -not $NonInteractive) {
+If (-not $Version -and
+	-not $Latest -and
+	-not $Branch -and
+	-not $NonInteractive) {
 
 	# Query download type / release stream
 	[System.Management.Automation.Host.ChoiceDescription[]]$downloadQuery_opts = @()
@@ -172,7 +175,7 @@ If ($Branch) {
 	}
 	catch {
 		$versionStatusCode = $_.Exception.Response.StatusCode.value__
-		Write-Warning "Failed to query GitHub for $project branches. Please check your internet connection and try again."
+		Write-Warning "Failed to query GitHub for $project branches."
 		throw "HTTP status code: $versionStatusCode"
 	}
 
@@ -285,7 +288,7 @@ Try {
 }
 catch {
 	$downloadStatusCode = $_.Exception.Response.StatusCode.value__
-	Write-Warning "Failed to download $project $releaseName. Please check your internet connection and try again."
+	Write-Warning "Failed to download $project $releaseName."
 	throw "HTTP status code: $downloadStatusCode"
 }
 

--- a/Installer.ps1
+++ b/Installer.ps1
@@ -304,7 +304,7 @@ catch {
 
 # Extract release to destination path
 Write-Output "Extracting files to '$InstallParentPath'..."
-Expand-Archive -Path "$env:TEMP\$outFile.zip" -DestinationPath "$InstallParentPath"
+Expand-Archive -Path "$env:TEMP\$outFile.zip" -DestinationPath "$InstallParentPath" -Force
 
 # Rename destination and tidy up
 Write-Output 'Renaming directory and tidying up...'
@@ -314,12 +314,13 @@ If (Test-Path "$InstallParentPath\$outFile") {
 Else {
 	# Necessary to handle branch downloads, which come as a ZIP containing a directory named similarly to "tigattack-VeeamNotify-2100906".
 	# Look for a directory less than 5 minutes old which matches the example name stated above.
-	(Get-ChildItem C:\VeeamScripts\ | Where-Object {
+	(Get-ChildItem $InstallParentPath | Where-Object {
 		$_.LastWriteTime -gt (Get-Date).AddMinutes(-5) -and
 		$_.Name -match "tigattack-$project-.*" -and
 		$_.PsIsContainer
 	})[0] | Rename-Item -NewName "$project"
 }
+
 Remove-Item -Path "$env:TEMP\$outFile.zip"
 
 If (-not $NonInteractive) {


### PR DESCRIPTION
* Fixes issue with download/extract failing due to Windows treating slashes in branch names as folders, causing rename to fail:  
`\W` replaces anything that isn't `a-z`, `A-Z`, `0-9` with chosen string.
* Fixes issue where branch download cannot be found after extraction.
* Fixes issue where installer does not halt after detecting existing install.
* Fixes poor matching logic in download type query.
* Get downloads from GitHub API instead of standard frontend URLs.
* Minor stylistic/output tweaks.