### PR TITLE
"Reload" .NET reflection using Get-VBRSession for GetByOriginalSessionId

### DIFF
--- a/resources/VBRSessionInfo.psm1
+++ b/resources/VBRSessionInfo.psm1
@@ -25,9 +25,9 @@ Function Get-VBRSessionInfo {
 			# Agent job
 			{$_ -eq 'EpAgentBackup'} {
 				# Fetch current session to load .NET module
-                # It appears some of the underlying .NET items are lazy-loaded, so this is necessary
-                # to load in whatever's required to utilise the GetByOriginalSessionId method.
-                # See https://forums.veeam.com/powershell-f26/want-to-capture-running-jobs-by-session-type-i-e-sobr-tiering-t75583.html#p486295
+				# It appears some of the underlying .NET items are lazy-loaded, so this is necessary
+				# to load in whatever's required to utilise the GetByOriginalSessionId method.
+				# See https://forums.veeam.com/powershell-f26/want-to-capture-running-jobs-by-session-type-i-e-sobr-tiering-t75583.html#p486295
 				Get-VBRSession -Id $SessionId | Out-Null
 				# Get the session details.
 				$session = [Veeam.Backup.Core.CBackupSession]::GetByOriginalSessionId($SessionId)

--- a/resources/VBRSessionInfo.psm1
+++ b/resources/VBRSessionInfo.psm1
@@ -25,6 +25,9 @@ Function Get-VBRSessionInfo {
 			# Agent job
 			{$_ -eq 'EpAgentBackup'} {
 				# Fetch current session to load .NET module
+                # It appears some of the underlying .NET items are lazy-loaded, so this is necessary
+                # to load in whatever's required to utilise the GetByOriginalSessionId method.
+                # See https://forums.veeam.com/powershell-f26/want-to-capture-running-jobs-by-session-type-i-e-sobr-tiering-t75583.html#p486295
 				Get-VBRSession -Id $SessionId | Out-Null
 				# Get the session details.
 				$session = [Veeam.Backup.Core.CBackupSession]::GetByOriginalSessionId($SessionId)

--- a/resources/VBRSessionInfo.psm1
+++ b/resources/VBRSessionInfo.psm1
@@ -25,7 +25,7 @@ Function Get-VBRSessionInfo {
 			# Agent job
 			{$_ -eq 'EpAgentBackup'} {
    				# Fetch current session to load .NET module
-       				Get-VBRSession -Id $SessionId | Out-Null
+       			Get-VBRSession -Id $SessionId | Out-Null
 				# Get the session details.
 				$session = [Veeam.Backup.Core.CBackupSession]::GetByOriginalSessionId($SessionId)
 

--- a/resources/VBRSessionInfo.psm1
+++ b/resources/VBRSessionInfo.psm1
@@ -24,8 +24,8 @@ Function Get-VBRSessionInfo {
 
 			# Agent job
 			{$_ -eq 'EpAgentBackup'} {
-   				# Fetch current session to load .NET module
-       			Get-VBRSession -Id $SessionId | Out-Null
+				# Fetch current session to load .NET module
+				Get-VBRSession -Id $SessionId | Out-Null
 				# Get the session details.
 				$session = [Veeam.Backup.Core.CBackupSession]::GetByOriginalSessionId($SessionId)
 

--- a/resources/VBRSessionInfo.psm1
+++ b/resources/VBRSessionInfo.psm1
@@ -24,6 +24,8 @@ Function Get-VBRSessionInfo {
 
 			# Agent job
 			{$_ -eq 'EpAgentBackup'} {
+   				# Fetch current session to load .NET module
+       				Get-VBRSession -Id $SessionId | Out-Null
 				# Get the session details.
 				$session = [Veeam.Backup.Core.CBackupSession]::GetByOriginalSessionId($SessionId)
 


### PR DESCRIPTION
More Tig's findings but my strange fix.

As per [this Veeam forum post](https://forums.veeam.com/powershell-f26/want-to-capture-running-jobs-by-session-type-i-e-sobr-tiering-t75583.html#p486295) on B&R 12 the module which allows GetByOriginalSessionId to be called isn't loaded until a cmdlet is ran related to the .NET reflection.

This is a very lazy fix that calls Get-VBRSession before using GetByOriginalSessionId with the current session Id and pipes it to null as the data it returns isn't viable to use for further outputs (Not enough info), however this does reload the .NET reflection, so guess it's good enough.

Should possibly fix #61 and *maybe* #55 