### PR TITLE
Fixing Send-Payload function

### DIFF
--- a/resources/NotificationHandler.psm1
+++ b/resources/NotificationHandler.psm1
@@ -772,7 +772,7 @@ function New-TelegramPayload {
 function Send-Payload {
 	[CmdletBinding()]
 	param (
-		[Parameter(Mandatory=$true)]
+		[Parameter(ValueFromPipeline,Mandatory=$true)]
 		$Payload,
 		$Uri,
 		$JSONPayload = $false


### PR DESCRIPTION
The commit bec6452 created a new function called "Send-JsonPayload".
This function is used in a pipeline command, with the parameter $Payload populated from previous command result.
However, this parameter is missing "ValueFromPipeline" keyword, resulting in AlertSender being stuck in background, waiting for input.