### PR TITLE
test(installer): fix test failures

### DIFF
--- a/Installer.ps1
+++ b/Installer.ps1
@@ -190,6 +190,7 @@ function Get-GitHubPRInfo {
 
 function Get-InstallationSource {
 	[CmdletBinding()]
+	[OutputType([System.Collections.Hashtable])]
 	param (
 		[Parameter(Mandatory)]
 		[string]$Project,
@@ -384,10 +385,17 @@ function Get-InstallationSource {
 		}
 
 		# Define download URL
-		$downloadUrl = Invoke-RestMethod "https://api.github.com/repos/tigattack/$Project/releases" | ForEach-Object {
-			if ($_.tag_name -eq $releaseName) {
-				$_.assets[0].browser_download_url
+		$releases = Invoke-RestMethod "https://api.github.com/repos/tigattack/$Project/releases"
+		foreach ($i in $releases) {
+			if ($i.tag_name -eq $releaseName) {
+				$downloadUrl = $i.assets[0].browser_download_url
+				break
 			}
+		}
+
+		if (-not $downloadUrl) {
+			Write-Warning "No download URL found for release '$releaseName'."
+			exit
 		}
 	}
 

--- a/tests/Installer.Tests.ps1
+++ b/tests/Installer.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Installer.ps1' {
 		$criticalFiles = @(
 			'.\Bootstrap.ps1',
 			'.\AlertSender.ps1',
-			'.\resources\version.txt',
+			'.\resources\version.txt'
 		)
 
 		# Define basic check for any installation

--- a/tests/Installer.Tests.ps1
+++ b/tests/Installer.Tests.ps1
@@ -23,12 +23,30 @@ Describe 'Installer.ps1' {
 			InstallParentPath = $installDir
 		}
 
-		# Define required files
-		$expectedFiles = @(
+		# Define critical files that should exist in any version
+		$criticalFiles = @(
+			'.\Bootstrap.ps1',
+			'.\AlertSender.ps1',
+			'.\resources\version.txt',
+		)
+
+		# Define basic check for any installation
+		[scriptblock]$criticalFilesCheck = {
+			# Check that installation directory exists
+			(Join-Path -Path "$installDir" -ChildPath 'VeeamNotify') | Should -Exist
+
+			# Check for critical files that should exist in any version
+			foreach ($file in $criticalFiles) {
+				Join-Path -Path "$installDir" -ChildPath 'VeeamNotify' | Join-Path -ChildPath $file | Should -Exist
+			}
+		}
+
+		# Define expected files for current repository state (for branch-based installations)
+		$repoFiles = @(
 			'.\Bootstrap.ps1',
 			'.\AlertSender.ps1'
 		)
-		$expectedFiles += $(
+		$repoFiles += $(
 			foreach ($dir in 'resources', 'config') {
 				$files = Get-ChildItem -Path "$(Split-Path -Path $PSScriptRoot -Parent)\$dir" -File -Recurse
 				foreach ($file in $files) {
@@ -37,9 +55,9 @@ Describe 'Installer.ps1' {
 			}
 		)
 
-		# Define required files check
-		[scriptblock]$expectedFilesCheck = {
-			foreach ($file in $expectedFiles) {
+		# Define required files check for branch-based installations
+		[scriptblock]$repoFilesCheck = {
+			foreach ($file in $repoFiles) {
 				Join-Path -Path "$installDir" -ChildPath 'VeeamNotify' | Join-Path -ChildPath $file | Should -Exist
 			}
 		}
@@ -51,8 +69,8 @@ Describe 'Installer.ps1' {
 		# Run installer
 		& $installerPath -Version $defaultVersion @installerParams
 
-		# Check for expected files
-		Invoke-Command -ScriptBlock $expectedFilesCheck
+		# Only check for critical files when installing from a specific version
+		Invoke-Command -ScriptBlock $criticalFilesCheck
 	}
 
 	It 'Install from latest release' {
@@ -60,8 +78,8 @@ Describe 'Installer.ps1' {
 		# Run installer
 		& $installerPath -Latest Release @installerParams
 
-		# Check for expected files
-		Invoke-Command -ScriptBlock $expectedFilesCheck
+		# Only check for critical files when installing from release
+		Invoke-Command -ScriptBlock $criticalFilesCheck
 	}
 
 	It 'Install from current branch' -Skip:($IsPr -or [string]::IsNullOrWhitespace($Branch)) {
@@ -69,8 +87,8 @@ Describe 'Installer.ps1' {
 		# Call installer with branch parameter
 		& $installerPath -Branch $Branch @installerParams
 
-		# Check for expected files
-		Invoke-Command -ScriptBlock $expectedFilesCheck
+		# Check for expected files from current stqte
+		Invoke-Command -ScriptBlock $repoFilesCheck
 	}
 
 	It 'Install from PR' -Skip:(-not $IsPr) {
@@ -78,8 +96,8 @@ Describe 'Installer.ps1' {
 		# Call installer with PR parameter
 		& $installerPath -PullRequest $PrId @installerParams
 
-		# Check for expected files
-		Invoke-Command -ScriptBlock $expectedFilesCheck
+		# Check for expected files from current stqte
+		Invoke-Command -ScriptBlock $repoFilesCheck
 	}
 
 	AfterEach {

--- a/tests/Installer.Tests.ps1
+++ b/tests/Installer.Tests.ps1
@@ -64,17 +64,7 @@ Describe 'Installer.ps1' {
 		Invoke-Command -ScriptBlock $expectedFilesCheck
 	}
 
-	It 'Install from main branch' {
-		$defaultBranch = 'main'
-		Write-Host "Installing from branch: $defaultBranch"
-		# Run installer
-		& $installerPath -Branch $defaultBranch @installerParams
-
-		# Check for expected files
-		Invoke-Command -ScriptBlock $expectedFilesCheck
-	}
-
-	It 'Install from current branch' -Skip:($IsPr -or $Branch -eq 'main' -or [string]::IsNullOrWhitespace($Branch)) {
+	It 'Install from current branch' -Skip:($IsPr -or [string]::IsNullOrWhitespace($Branch)) {
 		Write-Host "Installing from branch: $Branch"
 		# Call installer with branch parameter
 		& $installerPath -Branch $Branch @installerParams


### PR DESCRIPTION
The 'from version' and 'from release' tests would consistently fail until a new release was cut if any files were added or renamed.

This is fixed by only checking for a subset of files, files whose existence can **always** be expected.

The 'install from main branch' test is also removed because idk, it seemed a bit pointless.