### PR TITLE
fix(vbrsessioninfo): fix issues in agent job session discovery

### DIFF
--- a/AlertSender.ps1
+++ b/AlertSender.ps1
@@ -1,4 +1,5 @@
 param(
+	[String]$JobId,
 	[String]$SessionId,
 	[String]$JobType,
 	$Config,
@@ -72,7 +73,7 @@ try {
 	# Job info preparation
 
 	## Get the backup session.
-	$session = (Get-VBRSessionInfo -SessionId $SessionId -JobType $JobType).Session
+	$session = (Get-VBRSessionInfo -SessionId $SessionId -JobId $JobId -JobType $JobType).Session
 
 	## Initiate logger variable
 	$vbrSessionLogger = $session.Logger
@@ -84,7 +85,7 @@ try {
 		do {
 			Write-LogMessage -Tag 'INFO' -Message 'Session not completed. Sleeping...'
 			Start-Sleep -Seconds 10
-			$session = (Get-VBRSessionInfo -SessionId $SessionId -JobType $JobType).Session
+			$session = (Get-VBRSessionInfo -SessionId $SessionId -JobId $JobId -JobType $JobType).Session
 		}
 		while ($false -eq $session.Info.IsCompleted -and $stopwatch.Elapsed -lt $timeout)
 		$stopwatch.Stop()

--- a/Bootstrap.ps1
+++ b/Bootstrap.ps1
@@ -103,7 +103,13 @@ else {
 
 # Get the session information and name.
 Write-LogMessage -Tag 'INFO' -Message 'Getting VBR session information'
-$sessionInfo = Get-VBRSessionInfo -SessionId $SessionId -JobType $JobType
+try {
+	$sessionInfo = Get-VBRSessionInfo -SessionId $SessionId -JobId $JobId -JobType $JobType
+}
+catch {
+	Write-LogMessage -Tag 'ERROR' -Message "Failed to retrieve session information: $_"
+	exit 1
+}
 $jobName = $sessionInfo.JobName
 $vbrSessionLogger = $sessionInfo.Session.Logger
 

--- a/Bootstrap.ps1
+++ b/Bootstrap.ps1
@@ -126,7 +126,8 @@ else {
 	$job = Get-VBRTapeJob -WarningAction SilentlyContinue | Where-Object {$_.Id.ToString() -eq $JobId}
 	if ($job) {
 		$JobType = $job.Type
-	} else {
+	}
+	else {
 		Write-LogMessage -Tag 'ERROR' -Message "Job with ID $JobId not found in tape jobs. Exiting."
 		FinishBootstrap -Failed
 	}

--- a/resources/VBRSessionInfo.psm1
+++ b/resources/VBRSessionInfo.psm1
@@ -9,7 +9,9 @@ function Get-VBRSessionInfo {
 		[Parameter(Mandatory)][ValidateNotNullOrEmpty()]
 		[string]$SessionId,
 		[Parameter(Mandatory)][ValidateNotNullOrEmpty()]
-		[string]$JobType
+		[string]$JobType,
+		[Parameter(Mandatory)][ValidateNotNullOrEmpty()]
+		[string]$JobId
 	)
 
 	# Import VBR module
@@ -33,16 +35,16 @@ function Get-VBRSessionInfo {
 			# to load in whatever's required to utilise the GetByOriginalSessionId method.
 			# See https://forums.veeam.com/powershell-f26/want-to-capture-running-jobs-by-session-type-i-e-sobr-tiering-t75583.html#p486295
 			Get-VBRSession -Id $SessionId | Out-Null
-			# Get the session details.
-			$session = [Veeam.Backup.Core.CBackupSession]::GetByOriginalSessionId($SessionId)
 
-			# Copy the job's name to it's own variable.
-			if ($JobType -eq 'EpAgentBackup') {
-				$jobName = $job.Info.Name
+			# Get the session details.
+			$session = [Veeam.Backup.Core.CBackupSession]::GetByJob($JobId) | Select-Object -Last 1
+
+			if ($null -eq $session) {
+				throw "$JobType job session with ID '$SessionId' could not be found."
 			}
-			elseif ($JobType -in 'BackupToTape', 'FileToTape') {
-				$jobName = $job.Name
-			}
+
+			# Extract the job name from the session
+			$jobName = $session.Name
 		}
 	}
 


### PR DESCRIPTION
- Resolves #120 by passing the job ID in to the `Get-VBRSessionInfo` function and calling Veeam's `CBackupSession`'s `GetByJob` method, then filtering for the last result. A bit janky, but hardly more than before.  
  I'm unable to test this with tape jobs so hopefully it doesn't cause any issues ¯\_(ツ)_/¯
- Resolves invalid reference to non-existent `$job` variable.

Also improves error handling in `Bootstrap.ps1`:
- Catch more issues
- Stop logging and rename log file to include job name (if we got that far before failing) in all caught error scenarios.